### PR TITLE
fix(discovery): return `FileTypeUnknown` for non-SQL files in `ClassifyFile`

### DIFF
--- a/internal/discovery/classifier.go
+++ b/internal/discovery/classifier.go
@@ -12,7 +12,7 @@ func ClassifyFile(filename string) FileType {
 
 	// Check if it's a SQL file
 	if !strings.HasSuffix(lower, ".sql") {
-		return FileTypeSource // Non-SQL files are treated as source (edge case)
+		return FileTypeUnknown
 	}
 
 	// Test files match *_test.sql pattern

--- a/internal/discovery/classifier_test.go
+++ b/internal/discovery/classifier_test.go
@@ -1,0 +1,107 @@
+package discovery
+
+import (
+	"testing"
+)
+
+func TestClassifyFile_SQLFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     FileType
+	}{
+		{"test file lower-case", "foo_test.sql", FileTypeTest},
+		{"test file upper-case", "FOO_TEST.SQL", FileTypeTest},
+		{"test file mixed-case", "Foo_Test.Sql", FileTypeTest},
+		{"test file nested name", "create_user_test.sql", FileTypeTest},
+
+		{"source file simple", "foo.sql", FileTypeSource},
+		{"source file upper-case", "FOO.SQL", FileTypeSource},
+		{"source file mixed-case", "Foo.Sql", FileTypeSource},
+		{"source file containing test", "testing.sql", FileTypeSource},
+		{"source file ending with tests", "tests.sql", FileTypeSource},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyFile(tt.filename); got != tt.want {
+				t.Errorf("ClassifyFile(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFile_NonSQLFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     FileType
+	}{
+		{"README.md", "README.md", FileTypeUnknown},
+		{"upper-case README", "README.MD", FileTypeUnknown},
+		{"plain text file", "notes.txt", FileTypeUnknown},
+		{"yaml config", "config.yaml", FileTypeUnknown},
+		{"empty string", "", FileTypeUnknown},
+		{"no extension", "Makefile", FileTypeUnknown},
+		{"sql-like but wrong extension", "foo.sq", FileTypeUnknown},
+		{"sql embedded in name without suffix", "test.sql.bak", FileTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyFile(tt.filename); got != tt.want {
+				t.Errorf("ClassifyFile(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFile_DefaultReturnsUnknown(t *testing.T) {
+	// Out-of-range FileType should map to "unknown" in String().
+	ft := FileType(99)
+	if got := ft.String(); got != "unknown" {
+		t.Errorf("FileType(99).String() = %q, want %q", got, "unknown")
+	}
+}
+
+func TestFileType_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ft   FileType
+		want string
+	}{
+		{"test", FileTypeTest, "test"},
+		{"source", FileTypeSource, "source"},
+		{"unknown", FileTypeUnknown, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ft.String(); got != tt.want {
+				t.Errorf("FileType(%d).String() = %q, want %q", tt.ft, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want FileType
+	}{
+		{"test file absolute", "/tmp/foo_test.sql", FileTypeTest},
+		{"source file absolute", "/tmp/foo.sql", FileTypeSource},
+		{"non-sql file absolute", "/tmp/README.md", FileTypeUnknown},
+		{"test file with leading dir", "sub/dir/foo_test.sql", FileTypeTest},
+		{"non-sql with mixed path separators", `sub\dir\README.md`, FileTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyPath(tt.path); got != tt.want {
+				t.Errorf("ClassifyPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -14,8 +14,9 @@ type DiscoveredFile struct {
 type FileType int
 
 const (
-	FileTypeTest   FileType = iota // Matches *_test.sql
-	FileTypeSource                 // Does not match *_test.sql
+	FileTypeTest    FileType = iota // Matches *_test.sql
+	FileTypeSource                  // Does not match *_test.sql
+	FileTypeUnknown                 // Files that are not .sql
 )
 
 // String returns a string representation of FileType
@@ -25,6 +26,8 @@ func (ft FileType) String() string {
 		return "test"
 	case FileTypeSource:
 		return "source"
+	case FileTypeUnknown:
+		return "unknown"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
Implements finding **I7** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.