### PR TITLE
refactor(coverage): return sorted file lists from `GetFiles` and `GetFileList`

### DIFF
--- a/internal/coverage/collector.go
+++ b/internal/coverage/collector.go
@@ -3,6 +3,7 @@ package coverage
 import (
 	"fmt"
 	"maps"
+	"sort"
 	"sync"
 
 	"github.com/cybertec-postgresql/pgcov/internal/instrument"
@@ -98,7 +99,7 @@ func (c *Collector) GetFilePositionCoverage(filePath string) PositionHits {
 	return clone
 }
 
-// GetFileList returns a list of all files with coverage data
+// GetFileList returns a sorted list of all files with coverage data
 func (c *Collector) GetFileList() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -107,6 +108,7 @@ func (c *Collector) GetFileList() []string {
 	for file := range c.coverage.Positions {
 		files = append(files, file)
 	}
+	sort.Strings(files)
 	return files
 }
 

--- a/internal/coverage/collector_test.go
+++ b/internal/coverage/collector_test.go
@@ -267,6 +267,30 @@ func TestCollector_GetFileList(t *testing.T) {
 	}
 }
 
+// TestCollector_GetFileList_Sorted pins the contract that GetFileList returns
+// its result in lexicographic order regardless of insertion order, since
+// callers depend on this for deterministic report output.
+func TestCollector_GetFileList_Sorted(t *testing.T) {
+	c := NewCollector()
+	now := time.Now()
+	// Insert in non-alphabetical order so a naive map-iteration implementation
+	// would have a real chance of returning something else.
+	for _, name := range []string{"zeta.sql", "alpha.sql", "mike.sql", "beta.sql"} {
+		_ = c.AddSignal(runner.CoverageSignal{SignalID: name + ":0:10", Timestamp: now})
+	}
+
+	files := c.GetFileList()
+	want := []string{"alpha.sql", "beta.sql", "mike.sql", "zeta.sql"}
+	if len(files) != len(want) {
+		t.Fatalf("GetFileList() returned %d files, want %d (%v)", len(files), len(want), files)
+	}
+	for i, f := range files {
+		if f != want[i] {
+			t.Errorf("GetFileList()[%d] = %q, want %q", i, f, want[i])
+		}
+	}
+}
+
 func TestCollector_Coverage(t *testing.T) {
 	c := NewCollector()
 

--- a/internal/coverage/model.go
+++ b/internal/coverage/model.go
@@ -2,6 +2,7 @@ package coverage
 
 import (
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -86,12 +87,13 @@ func ParsePositionKey(posKey string) (startPos int, length int, err error) {
 	return
 }
 
-// GetFiles returns a list of all files with coverage data
+// GetFiles returns a sorted list of all files with coverage data
 func (c *Coverage) GetFiles() []string {
 	var files []string
 	for file := range c.Positions {
 		files = append(files, file)
 	}
+	sort.Strings(files)
 	return files
 }
 

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -29,12 +29,7 @@ type positionRange struct {
 
 // Format formats coverage data as HTML and writes to the writer
 func (r *HTMLReporter) Format(cov *coverage.Coverage, writer io.Writer) error {
-	// Sort files for deterministic output
-	var files []string
-	for file := range cov.Positions {
-		files = append(files, file)
-	}
-	sort.Strings(files)
+	files := cov.GetFiles()
 
 	// Write HTML header
 	if err := r.writeHeader(cov, files, writer); err != nil {

--- a/internal/report/lcov.go
+++ b/internal/report/lcov.go
@@ -21,12 +21,7 @@ func NewLCOVReporter() *LCOVReporter {
 
 // Format formats coverage data as LCOV and writes to the writer
 func (r *LCOVReporter) Format(cov *coverage.Coverage, writer io.Writer) error {
-	// Sort files for deterministic output
-	var files []string
-	for file := range cov.Positions {
-		files = append(files, file)
-	}
-	sort.Strings(files)
+	files := cov.GetFiles()
 
 	// Write LCOV format for each file
 	for _, file := range files {


### PR DESCRIPTION
Implements finding **I8** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.