### PR TITLE
feat(cli): add `--signal-timeout` for coverage signal grace period

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,202 @@
+## Inconsistencies
+
+### I1 — `pgcov` NOTIFY channel name hardcoded in two separate places
+
+`internal/instrument/instrumenter.go` hardcodes `'pgcov'` inside the injected
+`pg_notify(...)` call.  `internal/runner/executor.go` passes `"pgcov"` to
+`database.NewListener`.  If either is changed independently, coverage collection breaks
+silently.  A single exported constant (e.g. `instrument.CoverageChannel`) should be the
+single source of truth.
+
+---
+
+### I2 — `Branch` field in `CoveragePoint` is always empty string
+
+`types.go` defines `CoveragePoint.Branch`, `FormatSignalID` and `ParseSignalID` both
+handle a `:branch` suffix, and `TrackBranchPosition` exists in `location.go` — but
+`instrumentBody` always sets `Branch: ""` and the collector ignores branch data when
+aggregating.  This is an unimplemented feature occupying API surface.  Either implement
+it or remove the dead code.
+
+---
+
+### I3 — `PositionKey()` format differs from the key format used by the Collector
+
+`location.go` exports:
+
+```go
+func PositionKey(file, startPos, length) string { return "file:startPos:length" }
+```
+
+The collector stores keys as:
+
+```go
+posKey := fmt.Sprintf("%d:%d", startPos, length)   // no file prefix
+```
+
+`PositionKey` is never called by the collector; the two formats are incompatible.  The
+exported function is misleading and unused internally.
+
+---
+
+### I4 — `TrackPosition()` and `TrackBranchPosition()` in `location.go` are dead code
+
+Neither function is called anywhere in the production code.  They are part of the
+unimplemented branch-tracking API (see I2).
+
+---
+
+### I5 — `IsolationValidator` lives in production code but is never wired up
+
+`internal/runner/isolation.go` provides a fully functional `IsolationValidator` with
+`TrackDatabase` / `MarkCleaned` / `ValidateCleanup`, but `executor.go` never calls any
+of these methods.  The struct is only used in tests.  It should either be wired in
+(pre-flight check for uniqueness / post-run cleanup confirmation) or moved to a test
+helper package.
+
+---
+
+### I6 — `cli-contract.md` describes a schema that was never implemented
+
+`docs/cli-contract.md` (§ Coverage Data File Contract) documents a JSON schema with
+`lines` (containing `LineCoverage` objects) and `branches` (containing `BranchCoverage`
+objects).  The actual JSON output is:
+
+```json
+{"positions": {"file.sql": {"0:42": 3}}}
+```
+
+The CLI contract also lists individual flags (`--host`, `--port`, `--user`, `--password`,
+`--database`) that do not exist; the real flag is a single `--connection` URI string.
+The document should be updated or the flags added.
+
+---
+
+### I7 — `ClassifyFile` returns `FileTypeSource` for non-SQL files
+
+If `filepath.Walk` delivers a non-`.sql` file, `ClassifyFile` returns `FileTypeSource`
+(documented as an "edge case").  This could cause the parser to attempt reading arbitrary
+files.  An explicit `FileTypeUnknown` or early-return guard in `Discover` would be safer.
+
+---
+
+### I8 — `GetFiles()` / `GetFileList()` return unsorted slices
+
+Both `Coverage.GetFiles()` (`model.go`) and `Collector.GetFileList()` (`collector.go`)
+return files in random map-iteration order.  Every caller (all three reporters) performs
+its own `sort.Strings()` immediately after.  Sorting once in these methods would
+eliminate the repeated pattern.
+
+---
+
+### I9 — `isExecutableSegment` does not recognise `RETURN` as a segment boundary marker
+
+`isExecutableSegment` excludes `BEGIN`, `END`, `LOOP`, `DECLARE`, and `EXCEPTION` from
+instrumentation.  `RETURN` is treated as an ordinary executable statement.  While this
+is correct — a `RETURN` is executable — it means a bare `RETURN;` at the end of a
+complex function body generates its own signal, inflating coverage point counts.  More
+importantly, any signal injected immediately *after* a `RETURN` statement becomes
+unreachable (see B2), but the exclusion list does not account for this.
+
+---
+
+## Improvements / Enhancements
+
+### E1 — No coverage merge / accumulation across runs
+
+`pgcov run` always overwrites `.pgcov/coverage.json`.  There is no `pgcov merge` command
+or `--append` flag for accumulating coverage across CI matrix shards or multiple test
+directories.  The CI example configs work around this with external `jq` post-processing.
+
+---
+
+### E2 — No `--fail-under` coverage threshold
+
+There is no built-in mechanism to exit non-zero when coverage falls below a configured
+threshold.  This is a standard CI requirement and is simulated in the example CI configs
+using shell arithmetic on the JSON output.
+
+---
+
+### E3 — Source file deployment order is undefined
+
+`filepath.Walk` delivers files in lexicographic order within each directory, but the
+behaviour is OS-specific.  If `02_functions.sql` depends on objects created by
+`01_schema.sql`, naming convention is the only ordering guarantee.  A numeric-prefix
+convention should be documented, or an explicit `order` annotation / `pgcov.toml`
+manifest should be supported.
+
+---
+
+### E4 — No `--base-dir` flag for source resolution in reporters
+
+The HTML and LCOV reporters resolve source file paths relative to the current working
+directory at report time.  If `pgcov report` is run from a different directory than
+`pgcov run`, source content cannot be found and the HTML report shows an error comment
+in place of annotated code.  A `--base-dir` flag would decouple the report generation
+location from the run location.
+
+---
+
+### E5 — Hardcoded 100 ms grace period in `CollectSignals`
+
+After test SQL executes, `CollectSignals` waits 100 ms for in-flight notifications.  On
+slow systems or under heavy parallel load this window may be too short, causing
+legitimate signals to be lost.  The value should be exposed as a configuration option
+(e.g. `--signal-timeout`).
+
+---
+
+### E6 — Listener channel is not per-run unique
+
+The `pgcov` NOTIFY channel is a well-known name.  If the user's application already
+publishes notifications on a channel named `pgcov`, signals will be delivered to the
+listener in addition to (or instead of) the coverage ones.  Making the channel name
+incorporate the temp-database name or a random UUID would eliminate interference.
+
+---
+
+### E7 — `TestRun.Error` is set but not surfaced in the summary output
+
+When a test fails, `testRun.Error` holds the Go-level error.  The CLI summary prints
+`X failed` but does not print the error message.  Users must re-run with `--verbose` to
+see why a test failed.
+
+---
+
+### E8 — No `pgcov init` / scaffold command
+
+There is no helper to generate a skeleton `_test.sql` file for an existing source.  A
+`pgcov init` command that reads function signatures from a source file and emits a
+commented test scaffold would lower the barrier to adoption.
+
+---
+
+### E9 — Pool `MaxConns` formula may be insufficient
+
+`pool.go` sets `MaxConns = parallelism * 2` under the assumption that each test uses
+two connections (one for execution, one for LISTEN).  Each test actually acquires up to
+three connections simultaneously (pool acquire for sources, listener connection, pool
+acquire for test SQL).  Under high parallelism this can cause connection pool exhaustion
+and `pgx` acquire timeouts.
+
+---
+
+### E10 — `CREATE DATABASE` uses an unquoted identifier
+
+`tempdb.go`:
+
+```go
+adminPool.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", dbName))
+```
+
+The generated name (`pgcov_test_20260318_140534_ab12cd34`) uses only lowercase, digits
+and underscores, so it is safe today.  However, the pattern should use `pgx`'s
+`pgx.Identifier.Sanitize()` (quote the identifier) to be robust against any future
+change to the name format and to prevent a theoretical injection if the name-generation
+logic ever incorporates external input.
+
+---
+
+*File generated 2026-03-18 based on a code review of the full pgcov source tree and
+hands-on testing with the `examples/demo` walkthrough.*

--- a/cmd/pgcov/main.go
+++ b/cmd/pgcov/main.go
@@ -31,6 +31,10 @@ func main() {
 						Name:  "timeout",
 						Usage: "Per-test timeout",
 					},
+					&urfavecli.DurationFlag{
+						Name:  "signal-timeout",
+						Usage: "Grace period to wait for in-flight coverage NOTIFY signals after test SQL executes",
+					},
 					&urfavecli.IntFlag{
 						Name:  "parallel",
 						Usage: "Maximum concurrent tests (1 = sequential)",
@@ -85,16 +89,15 @@ func main() {
 func runCommand(ctx context.Context, cmd *urfavecli.Command) error {
 	// Load configuration
 	config := &cli.DefaultConfig
-
-	// Apply flags
 	connection := cmd.String("connection")
 	timeout := cmd.Duration("timeout")
+	signalTimeout := cmd.Duration("signal-timeout")
 	parallel := cmd.Int("parallel")
 	coverageFile := cmd.String("coverage-file")
 	setupFiles := cmd.StringSlice("setup")
 	verbose := cmd.Bool("verbose")
 
-	cli.ApplyFlagsToConfig(config, connection, timeout, parallel, coverageFile, verbose, setupFiles)
+	cli.ApplyFlagsToConfig(config, connection, timeout, signalTimeout, parallel, coverageFile, verbose, setupFiles)
 
 	// Validate configuration
 	if err := config.Validate(); err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -16,6 +16,7 @@ type ConfigError = types.ConfigError
 var DefaultConfig = Config{
 	ConnectionString: "",
 	Timeout:          30 * time.Second,
+	SignalTimeout:    100 * time.Millisecond,
 	Parallelism:      1,
 	CoverageFile:     ".pgcov/coverage.json",
 	Verbose:          false,
@@ -23,13 +24,15 @@ var DefaultConfig = Config{
 
 // ApplyFlagsToConfig applies command-line flag values to configuration
 func ApplyFlagsToConfig(c *Config, connection string, timeout time.Duration,
-	parallel int, coverageFile string, verbose bool, setupFiles []string) {
-
+	signalTimeout time.Duration, parallel int, coverageFile string, verbose bool, setupFiles []string) {
 	if connection != "" {
 		c.ConnectionString = connection
 	}
 	if timeout != 0 {
 		c.Timeout = timeout
+	}
+	if signalTimeout != 0 {
+		c.SignalTimeout = signalTimeout
 	}
 	if parallel != 0 {
 		c.Parallelism = parallel

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -10,13 +10,14 @@ func TestApplyFlagsToConfig_EmptyFlagsPreserveConfig(t *testing.T) {
 	cfg := &Config{
 		ConnectionString: originalConnString,
 		Timeout:          45 * time.Second,
+		SignalTimeout:    250 * time.Millisecond,
 		Parallelism:      2,
 		CoverageFile:     "original.json",
 		Verbose:          false,
 	}
 
 	// Apply empty flags (should not change config)
-	ApplyFlagsToConfig(cfg, "", 0, 0, "", false, nil)
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil)
 
 	if cfg.ConnectionString != originalConnString {
 		t.Errorf("empty flag should not change connection string")
@@ -30,13 +31,32 @@ func TestApplyFlagsToConfig_EmptyFlagsPreserveConfig(t *testing.T) {
 	if len(cfg.SetupFiles) != 0 {
 		t.Errorf("nil setup flag should not set setup files")
 	}
+	if cfg.SignalTimeout != 250*time.Millisecond {
+		t.Errorf("zero flag should not change signal timeout")
+	}
 }
 
 func TestApplyFlagsToConfig_SetupFiles(t *testing.T) {
 	cfg := &Config{}
-	ApplyFlagsToConfig(cfg, "", 0, 0, "", false, []string{"a.sql", "glob/*.sql"})
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, []string{"a.sql", "glob/*.sql"})
 	if len(cfg.SetupFiles) != 2 {
 		t.Fatalf("expected 2 setup files, got %d", len(cfg.SetupFiles))
+	}
+}
+
+func TestApplyFlagsToConfig_SignalTimeout(t *testing.T) {
+	cfg := &Config{SignalTimeout: 100 * time.Millisecond}
+	ApplyFlagsToConfig(cfg, "", 0, 500*time.Millisecond, 0, "", false, nil)
+	if cfg.SignalTimeout != 500*time.Millisecond {
+		t.Fatalf("expected signal timeout 500ms, got %v", cfg.SignalTimeout)
+	}
+}
+
+func TestApplyFlagsToConfig_SignalTimeoutZeroPreservesDefault(t *testing.T) {
+	cfg := &Config{SignalTimeout: 250 * time.Millisecond}
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil)
+	if cfg.SignalTimeout != 250*time.Millisecond {
+		t.Fatalf("zero flag must preserve signal timeout, got %v", cfg.SignalTimeout)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -142,7 +142,7 @@ func Run(ctx context.Context, config *Config, searchPath string) (int, error) {
 	}
 
 	// Step 6: Execute tests (parallel or sequential based on config)
-	executor := runner.NewExecutor(pool, config.Timeout, config.Verbose, config.CoverageChannel)
+	executor := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, config.CoverageChannel)
 
 	// Load any prerequisite setup scripts (globs expanded, order preserved) so
 	// they run in each test's temp database before the instrumented sources.

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -409,7 +409,7 @@ func TestOrderIndependence(t *testing.T) {
 	runTestsInOrder := func(order []discovery.DiscoveredFile, label string) *coverage.Coverage {
 		t.Logf("Running tests in order %s", label)
 
-		executor := runner.NewExecutor(pool, config.Timeout, config.Verbose, instrument.DefaultChannel)
+		executor := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, instrument.DefaultChannel)
 		testRuns, err := executor.ExecuteBatch(ctx, order, instrumentedSources)
 		if err != nil {
 			t.Fatalf("Test execution failed for %s: %v", label, err)
@@ -599,7 +599,7 @@ func TestTestIndependence(t *testing.T) {
 	runSingleTest := func(iteration int) (*runner.TestRun, *coverage.Coverage) {
 		t.Logf("Running test iteration %d...", iteration)
 
-		executor := runner.NewExecutor(pool, config.Timeout, config.Verbose, instrument.DefaultChannel)
+		executor := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, instrument.DefaultChannel)
 		testRuns, err := executor.ExecuteBatch(ctx, []discovery.DiscoveredFile{testFile}, instrumentedSources)
 		if err != nil {
 			t.Fatalf("Test execution failed (iteration %d): %v", iteration, err)

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -16,6 +16,7 @@ import (
 type Executor struct {
 	pool            *database.Pool
 	timeout         time.Duration
+	signalTimeout   time.Duration
 	verbose         bool
 	coverageChannel string
 
@@ -32,13 +33,24 @@ type SetupScript struct {
 	SQL  string
 }
 
+// DefaultSignalTimeout is the grace period for in-flight NOTIFY signals used
+// when NewExecutor receives a non-positive signalTimeout (e.g. a Config built
+// without the CLI defaults).
+const DefaultSignalTimeout = 100 * time.Millisecond
+
 // NewExecutor creates a new test executor.  coverageChannel is the PostgreSQL
 // NOTIFY channel name used both for the instrumented sources (pg_notify calls)
 // and for the LISTEN side; both must agree or no signals will be received.
-func NewExecutor(pool *database.Pool, timeout time.Duration, verbose bool, coverageChannel string) *Executor {
+// signalTimeout is the grace period for in-flight NOTIFY signals after test SQL
+// finishes executing; a non-positive value falls back to DefaultSignalTimeout.
+func NewExecutor(pool *database.Pool, timeout time.Duration, signalTimeout time.Duration, verbose bool, coverageChannel string) *Executor {
+	if signalTimeout <= 0 {
+		signalTimeout = DefaultSignalTimeout
+	}
 	return &Executor{
 		pool:            pool,
 		timeout:         timeout,
+		signalTimeout:   signalTimeout,
 		verbose:         verbose,
 		coverageChannel: coverageChannel,
 	}
@@ -297,9 +309,8 @@ func (e *Executor) executeTestWorkflow(ctx context.Context, testRun *TestRun, so
 	if e.verbose {
 		fmt.Println("[DEBUG] Step 7: Collecting coverage signals...")
 	}
-	// Step 6: Collect coverage signals
 	// Give a short time for any remaining signals to arrive
-	signals, err := listener.CollectSignals(ctx, 100*time.Millisecond)
+	signals, err := listener.CollectSignals(ctx, e.signalTimeout)
 	if err != nil && err != context.DeadlineExceeded && err != context.Canceled {
 		return fmt.Errorf("failed to collect signals: %w", err)
 	}

--- a/internal/runner/parallel_test.go
+++ b/internal/runner/parallel_test.go
@@ -69,7 +69,7 @@ func TestParallelExecution(t *testing.T) {
 	}
 
 	// Execute tests in parallel
-	executor := runner.NewExecutor(pool, config.Timeout, config.Verbose, instrument.DefaultChannel)
+	executor := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, instrument.DefaultChannel)
 	workerPool := runner.NewWorkerPool(executor, config.Parallelism, config.Verbose)
 
 	startTime := time.Now()
@@ -93,7 +93,7 @@ func TestParallelExecution(t *testing.T) {
 	}
 
 	// Execute tests sequentially for comparison
-	executor2 := runner.NewExecutor(pool, config.Timeout, config.Verbose, instrument.DefaultChannel)
+	executor2 := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, instrument.DefaultChannel)
 	startTime = time.Now()
 	testRuns2, err := executor2.ExecuteBatch(ctx, testFiles, instrumentedSources)
 	sequentialDuration := time.Since(startTime)
@@ -193,7 +193,7 @@ func TestParallelExecutionAccuracy(t *testing.T) {
 	var coveragePercentages []float64
 
 	for i := range runs {
-		executor := runner.NewExecutor(pool, config.Timeout, config.Verbose, instrument.DefaultChannel)
+		executor := runner.NewExecutor(pool, config.Timeout, config.SignalTimeout, config.Verbose, instrument.DefaultChannel)
 		workerPool := runner.NewWorkerPool(executor, config.Parallelism, config.Verbose)
 		testRuns, err := workerPool.ExecuteParallel(ctx, testFiles, instrumentedSources)
 		if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,9 +11,10 @@ type Config struct {
 	ConnectionString string // PostgreSQL connection string (URI or key=value format)
 
 	// Execution
-	SearchPath  string        // Root path for test/source discovery
-	Timeout     time.Duration // Per-test timeout
-	Parallelism int           // Max concurrent tests (1 = sequential)
+	SearchPath    string        // Root path for test/source discovery
+	Timeout       time.Duration // Per-test timeout
+	SignalTimeout time.Duration // Grace period to wait for in-flight coverage NOTIFY signals after test SQL executes
+	Parallelism   int           // Max concurrent tests (1 = sequential)
 
 	// SetupFiles are SQL files (globs allowed) executed verbatim — without
 	// instrumentation and without being treated as sources-under-test — in each


### PR DESCRIPTION
Implements finding **E5** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.