### PR TITLE
feat(cli): print failed test errors in run summary

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -198,12 +198,19 @@ func Run(ctx context.Context, config *Config, searchPath string) (int, error) {
 	summary := runner.SummarizeRuns(testRuns)
 	coveragePercent := collector.TotalCoveragePercent()
 
+	// Surface per-test failure messages so users do not have to re-run with
+	// --verbose to see why a test failed. Each line is prefixed with "FAILED "
+	// to match the run-level status badge printed earlier in --verbose mode.
+	for _, line := range runner.FormatFailedTests(testRuns) {
+		fmt.Println(line)
+	}
 	fmt.Printf("\n")
 	fmt.Printf("Tests:    %d passed, %d failed, %d total\n",
 		summary.PassedTests, summary.FailedTests, summary.TotalTests)
 	fmt.Printf("Coverage: %.2f%%\n", coveragePercent)
 	fmt.Printf("Time:     %v\n", time.Since(startTime).Round(time.Millisecond))
 	fmt.Printf("\n")
+
 	fmt.Printf("Coverage data written to %s\n", config.CoverageFile)
 
 	// Return appropriate exit code

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cybertec-postgresql/pgcov/internal/discovery"
@@ -80,4 +81,24 @@ func (s *TestSummary) ExitCode() int {
 		return 0
 	}
 	return 1
+}
+
+// FormatFailedTests renders one human-readable line per failed test run,
+// prefixed with "FAILED ". Runs that are not TestFailed (or have no Error)
+// are skipped. The returned slice is nil when there is nothing to report,
+// so callers can print it directly with no extra guarding. Output is built
+// (not printed) here so it stays unit-testable without a live database.
+func FormatFailedTests(runs []*TestRun) []string {
+	var lines []string
+	for _, run := range runs {
+		if run == nil || run.Status != TestFailed || run.Error == nil {
+			continue
+		}
+		relPath := ""
+		if run.Test != nil {
+			relPath = run.Test.RelativePath
+		}
+		lines = append(lines, fmt.Sprintf("FAILED %s: %v", relPath, run.Error))
+	}
+	return lines
 }

--- a/internal/runner/types_test.go
+++ b/internal/runner/types_test.go
@@ -1,0 +1,110 @@
+package runner_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cybertec-postgresql/pgcov/internal/discovery"
+	"github.com/cybertec-postgresql/pgcov/internal/runner"
+)
+
+func TestFormatFailedTests(t *testing.T) {
+	tests := []struct {
+		name    string
+		runs    []*runner.TestRun
+		want    []string
+		wantNil bool
+	}{
+		{
+			name:    "no runs",
+			runs:    nil,
+			wantNil: true,
+		},
+		{
+			name: "all passed",
+			runs: []*runner.TestRun{
+				{Test: &discovery.DiscoveredFile{RelativePath: "a_test.sql"}, Status: runner.TestPassed},
+			},
+			wantNil: true,
+		},
+		{
+			name: "failed with error",
+			runs: []*runner.TestRun{
+				{
+					Test:   &discovery.DiscoveredFile{RelativePath: "dir/broken_test.sql"},
+					Status: runner.TestFailed,
+					Error:  errors.New("test execution failed: syntax error at or near \"FORM\""),
+				},
+			},
+			want: []string{
+				"FAILED dir/broken_test.sql: test execution failed: syntax error at or near \"FORM\"",
+			},
+		},
+		{
+			name: "mixed statuses only failed surfaces",
+			runs: []*runner.TestRun{
+				{Test: &discovery.DiscoveredFile{RelativePath: "a_test.sql"}, Status: runner.TestPassed},
+				{
+					Test:   &discovery.DiscoveredFile{RelativePath: "b_test.sql"},
+					Status: runner.TestFailed,
+					Error:  errors.New("boom"),
+				},
+				{
+					Test:   &discovery.DiscoveredFile{RelativePath: "c_test.sql"},
+					Status: runner.TestTimeout,
+					Error:  errors.New("context deadline exceeded"),
+				},
+				{
+					Test:   &discovery.DiscoveredFile{RelativePath: "d_test.sql"},
+					Status: runner.TestFailed,
+					// No error attached — runner normally populates this, but
+					// the helper must not panic if a caller hands in a run
+					// with Status=TestFailed and Error=nil.
+				},
+			},
+			want: []string{
+				"FAILED b_test.sql: boom",
+			},
+		},
+		{
+			name: "nil entry safely skipped",
+			runs: []*runner.TestRun{
+				nil,
+				{
+					Test:   &discovery.DiscoveredFile{RelativePath: "x_test.sql"},
+					Status: runner.TestFailed,
+					Error:  errors.New("kaboom"),
+				},
+			},
+			want: []string{
+				"FAILED x_test.sql: kaboom",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runner.FormatFailedTests(tc.runs)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d line(s), got %d: %v", len(tc.want), len(got), got)
+			}
+			for i, line := range got {
+				if line != tc.want[i] {
+					t.Errorf("line %d: want %q, got %q", i, tc.want[i], line)
+				}
+				// Sanity: every emitted line carries the FAILED prefix so the
+				// summary block stays scannable next to the "Tests:" line.
+				if !strings.HasPrefix(line, "FAILED ") {
+					t.Errorf("line %d missing FAILED prefix: %q", i, line)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements finding **E7** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.