### PR TITLE
feat(cli): add `--fail-under` coverage threshold to run command

### DIFF
--- a/cmd/pgcov/main.go
+++ b/cmd/pgcov/main.go
@@ -51,6 +51,10 @@ func main() {
 						Name:  "verbose",
 						Usage: "Enable debug output",
 					},
+					&urfavecli.Float64Flag{
+						Name:  "fail-under",
+						Usage: "Fail (exit 1) if total coverage percentage is below this threshold (0 = disabled)",
+					},
 				},
 			},
 			{
@@ -96,8 +100,9 @@ func runCommand(ctx context.Context, cmd *urfavecli.Command) error {
 	coverageFile := cmd.String("coverage-file")
 	setupFiles := cmd.StringSlice("setup")
 	verbose := cmd.Bool("verbose")
+	failUnder := cmd.Float64("fail-under")
 
-	cli.ApplyFlagsToConfig(config, connection, timeout, signalTimeout, parallel, coverageFile, verbose, setupFiles)
+	cli.ApplyFlagsToConfig(config, connection, timeout, signalTimeout, parallel, coverageFile, verbose, setupFiles, failUnder)
 
 	// Validate configuration
 	if err := config.Validate(); err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -24,7 +24,7 @@ var DefaultConfig = Config{
 
 // ApplyFlagsToConfig applies command-line flag values to configuration
 func ApplyFlagsToConfig(c *Config, connection string, timeout time.Duration,
-	signalTimeout time.Duration, parallel int, coverageFile string, verbose bool, setupFiles []string) {
+	signalTimeout time.Duration, parallel int, coverageFile string, verbose bool, setupFiles []string, failUnder float64) {
 	if connection != "" {
 		c.ConnectionString = connection
 	}
@@ -44,4 +44,5 @@ func ApplyFlagsToConfig(c *Config, connection string, timeout time.Duration,
 		c.SetupFiles = setupFiles
 	}
 	c.Verbose = verbose
+	c.FailUnder = failUnder
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -17,7 +17,7 @@ func TestApplyFlagsToConfig_EmptyFlagsPreserveConfig(t *testing.T) {
 	}
 
 	// Apply empty flags (should not change config)
-	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil)
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil, 0)
 
 	if cfg.ConnectionString != originalConnString {
 		t.Errorf("empty flag should not change connection string")
@@ -38,7 +38,7 @@ func TestApplyFlagsToConfig_EmptyFlagsPreserveConfig(t *testing.T) {
 
 func TestApplyFlagsToConfig_SetupFiles(t *testing.T) {
 	cfg := &Config{}
-	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, []string{"a.sql", "glob/*.sql"})
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, []string{"a.sql", "glob/*.sql"}, 0)
 	if len(cfg.SetupFiles) != 2 {
 		t.Fatalf("expected 2 setup files, got %d", len(cfg.SetupFiles))
 	}
@@ -46,7 +46,7 @@ func TestApplyFlagsToConfig_SetupFiles(t *testing.T) {
 
 func TestApplyFlagsToConfig_SignalTimeout(t *testing.T) {
 	cfg := &Config{SignalTimeout: 100 * time.Millisecond}
-	ApplyFlagsToConfig(cfg, "", 0, 500*time.Millisecond, 0, "", false, nil)
+	ApplyFlagsToConfig(cfg, "", 0, 500*time.Millisecond, 0, "", false, nil, 0)
 	if cfg.SignalTimeout != 500*time.Millisecond {
 		t.Fatalf("expected signal timeout 500ms, got %v", cfg.SignalTimeout)
 	}
@@ -54,7 +54,7 @@ func TestApplyFlagsToConfig_SignalTimeout(t *testing.T) {
 
 func TestApplyFlagsToConfig_SignalTimeoutZeroPreservesDefault(t *testing.T) {
 	cfg := &Config{SignalTimeout: 250 * time.Millisecond}
-	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil)
+	ApplyFlagsToConfig(cfg, "", 0, 0, 0, "", false, nil, 0)
 	if cfg.SignalTimeout != 250*time.Millisecond {
 		t.Fatalf("zero flag must preserve signal timeout, got %v", cfg.SignalTimeout)
 	}
@@ -174,6 +174,50 @@ func TestConfigValidate_EmptyCoverageFile(t *testing.T) {
 	}
 	if configErr.Suggestion == "" {
 		t.Error("expected suggestion to be provided")
+	}
+}
+
+func TestConfigValidate_FailUnder(t *testing.T) {
+	tests := []struct {
+		name      string
+		failUnder float64
+		wantErr   bool
+	}{
+		{"zero disables", 0, false},
+		{"valid boundary zero", 0.0, false},
+		{"valid mid", 80.5, false},
+		{"valid boundary hundred", 100, false},
+		{"negative invalid", -1, true},
+		{"too high invalid", 100.01, true},
+		{"way too high invalid", 250, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				ConnectionString: "host=localhost port=5432 dbname=postgres",
+				Timeout:          30 * time.Second,
+				Parallelism:      1,
+				CoverageFile:     ".pgcov/coverage.json",
+				FailUnder:        tt.failUnder,
+			}
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error for fail-under=%g", tt.failUnder)
+				}
+				configErr, ok := err.(*ConfigError)
+				if !ok {
+					t.Fatalf("expected ConfigError, got %T", err)
+				}
+				if configErr.Field != "fail-under" {
+					t.Errorf("expected field 'fail-under', got %q", configErr.Field)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for fail-under=%g: %v", tt.failUnder, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -210,9 +210,14 @@ func Run(ctx context.Context, config *Config, searchPath string) (int, error) {
 	fmt.Printf("Coverage: %.2f%%\n", coveragePercent)
 	fmt.Printf("Time:     %v\n", time.Since(startTime).Round(time.Millisecond))
 	fmt.Printf("\n")
-
 	fmt.Printf("Coverage data written to %s\n", config.CoverageFile)
 
-	// Return appropriate exit code
-	return summary.ExitCode(), nil
+	// Determine exit code: test failures take precedence; otherwise check threshold.
+	exitCode := summary.ExitCode()
+	if exitCode == 0 && config.FailUnder > 0 && coveragePercent < config.FailUnder {
+		fmt.Printf("Coverage %.2f%% is below threshold %.2f%%\n", coveragePercent, config.FailUnder)
+		return 1, nil
+	}
+
+	return exitCode, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,6 +36,10 @@ type Config struct {
 	// letters, digits, underscore) so they can be safely interpolated into
 	// LISTEN/<channel> SQL without escaping.
 	CoverageChannel string
+
+	// FailUnder is the minimum total coverage percentage required to exit 0
+	// (0 = disabled).
+	FailUnder float64
 }
 
 // ConfigError represents a configuration validation error
@@ -103,6 +107,16 @@ func (c *Config) Validate() error {
 			Field:      "coverage-file",
 			Message:    "coverage file path is required",
 			Suggestion: "Set via --coverage-file flag. Default is '.pgcov/coverage.json'.",
+		}
+	}
+
+	// Validate fail-under threshold (0 disables, otherwise must be 0-100)
+	if c.FailUnder < 0 || c.FailUnder > 100 {
+		return &ConfigError{
+			Field:      "fail-under",
+			Value:      c.FailUnder,
+			Message:    fmt.Sprintf("fail-under must be between 0 and 100, got: %g", c.FailUnder),
+			Suggestion: "Use --fail-under=N where N is a percentage in [0, 100]. Use 0 to disable the threshold.",
 		}
 	}
 


### PR DESCRIPTION
Implements finding **E2** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.