### PR TITLE
feat(cli): add `merge` command to accumulate coverage across runs

### DIFF
--- a/cmd/pgcov/main.go
+++ b/cmd/pgcov/main.go
@@ -80,6 +80,19 @@ func main() {
 					},
 				},
 			},
+			{
+				Name:   "merge",
+				Usage:  "Merge two or more coverage JSON files (positional args). Per-position hit counts are summed across inputs.",
+				Action: mergeCommand,
+				Flags: []urfavecli.Flag{
+					&urfavecli.StringFlag{
+						Name:    "output",
+						Aliases: []string{"o"},
+						Usage:   "Output file path (use - for stdout)",
+						Value:   "-",
+					},
+				},
+			},
 		},
 	}
 
@@ -137,4 +150,11 @@ func reportCommand(ctx context.Context, cmd *urfavecli.Command) error {
 	coverageFile := cmd.String("coverage-file")
 
 	return cli.Report(ctx, coverageFile, format, output)
+}
+
+// mergeCommand handles the 'pgcov merge' command
+func mergeCommand(ctx context.Context, cmd *urfavecli.Command) error {
+	output := cmd.String("output")
+	inputs := cmd.Args().Slice()
+	return cli.Merge(ctx, inputs, output)
 }

--- a/internal/cli/merge.go
+++ b/internal/cli/merge.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/cybertec-postgresql/pgcov/internal/coverage"
+)
+
+// Merge loads two or more coverage JSON files, merges their per-position hit
+// counts, and writes the result to outputPath. A "-" or empty outputPath
+// writes the merged JSON to stdout; any other path is persisted via
+// coverage.NewStore. Save.
+func Merge(_ context.Context, inputs []string, outputPath string) error {
+	if len(inputs) < 2 {
+		return fmt.Errorf("merge requires at least 2 input coverage files (got %d)", len(inputs))
+	}
+
+	coverages := make([]*coverage.Coverage, 0, len(inputs))
+	for _, path := range inputs {
+		store := coverage.NewStore(path)
+		cov, err := store.Load()
+		if err != nil {
+			return fmt.Errorf("failed to load %s: %w", path, err)
+		}
+		coverages = append(coverages, cov)
+	}
+
+	merged := coverage.Merge(coverages...)
+
+	if outputPath == "" || outputPath == "-" {
+		data, err := json.MarshalIndent(merged, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal merged coverage: %w", err)
+		}
+		data = append(data, '\n')
+		if _, err := os.Stdout.Write(data); err != nil {
+			return fmt.Errorf("failed to write merged coverage to stdout: %w", err)
+		}
+		return nil
+	}
+
+	store := coverage.NewStore(outputPath)
+	if err := store.Save(merged); err != nil {
+		return fmt.Errorf("failed to save merged coverage: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Merged %d coverage files into %s\n", len(inputs), outputPath)
+	return nil
+}

--- a/internal/coverage/merge_test.go
+++ b/internal/coverage/merge_test.go
@@ -1,0 +1,104 @@
+package coverage
+
+import (
+	"testing"
+)
+
+func TestMerge_OverlappingAndDisjoint(t *testing.T) {
+	a := NewCoverage()
+	a.AddPosition("a.sql", 100, 50, 2)
+	a.AddPosition("a.sql", 200, 60, 1)
+	a.AddPosition("shared.sql", 10, 5, 3)
+
+	b := NewCoverage()
+	b.AddPosition("a.sql", 100, 50, 5)    // overlaps a.sql:100:50 -> 2+5 = 7
+	b.AddPosition("b.sql", 300, 70, 4)    // disjoint
+	b.AddPosition("shared.sql", 10, 5, 1) // overlaps shared.sql:10:5 -> 3+1 = 4
+
+	merged := Merge(a, b)
+
+	if merged.Positions["a.sql"]["100:50"] != 7 {
+		t.Errorf("a.sql:100:50 = %d, want 7", merged.Positions["a.sql"]["100:50"])
+	}
+	if merged.Positions["a.sql"]["200:60"] != 1 {
+		t.Errorf("a.sql:200:60 = %d, want 1", merged.Positions["a.sql"]["200:60"])
+	}
+	if merged.Positions["b.sql"]["300:70"] != 4 {
+		t.Errorf("b.sql:300:70 = %d, want 4", merged.Positions["b.sql"]["300:70"])
+	}
+	if merged.Positions["shared.sql"]["10:5"] != 4 {
+		t.Errorf("shared.sql:10:5 = %d, want 4", merged.Positions["shared.sql"]["10:5"])
+	}
+}
+
+func TestMerge_SumsHitCounts(t *testing.T) {
+	a := NewCoverage()
+	a.AddPosition("f.sql", 0, 10, 1)
+
+	b := NewCoverage()
+	b.AddPosition("f.sql", 0, 10, 1)
+
+	c := NewCoverage()
+	c.AddPosition("f.sql", 0, 10, 1)
+
+	merged := Merge(a, b, c)
+
+	got := merged.Positions["f.sql"]["0:10"]
+	if got != 3 {
+		t.Errorf("f.sql:0:10 = %d, want 3", got)
+	}
+}
+
+func TestMerge_Empty(t *testing.T) {
+	merged := Merge()
+	if merged == nil {
+		t.Fatal("Merge() returned nil")
+	}
+	if len(merged.Positions) != 0 {
+		t.Errorf("empty merge produced positions: %v", merged.Positions)
+	}
+	if merged.Version != NewCoverage().Version {
+		t.Errorf("empty merge Version = %q, want %q", merged.Version, NewCoverage().Version)
+	}
+}
+
+func TestMerge_NilInputs(t *testing.T) {
+	a := NewCoverage()
+	a.AddPosition("f.sql", 0, 1, 1)
+
+	merged := Merge(nil, a, nil)
+	if merged.Positions["f.sql"]["0:1"] != 1 {
+		t.Errorf("nil-aware merge lost a's hit count: got %d, want 1",
+			merged.Positions["f.sql"]["0:1"])
+	}
+}
+
+func TestMerge_DoesNotMutateInputs(t *testing.T) {
+	a := NewCoverage()
+	a.AddPosition("f.sql", 0, 1, 2)
+	b := NewCoverage()
+	b.AddPosition("f.sql", 0, 1, 3)
+
+	_ = Merge(a, b)
+
+	if a.Positions["f.sql"]["0:1"] != 2 {
+		t.Errorf("Merge mutated a: got %d, want 2", a.Positions["f.sql"]["0:1"])
+	}
+	if b.Positions["f.sql"]["0:1"] != 3 {
+		t.Errorf("Merge mutated b: got %d, want 3", b.Positions["f.sql"]["0:1"])
+	}
+}
+
+func TestMerge_VersionAndTimestamp(t *testing.T) {
+	c := NewCoverage()
+	c.Version = "legacy"
+	c.AddPosition("f.sql", 0, 1, 1)
+
+	merged := Merge(c)
+	if merged.Version != "1.0" {
+		t.Errorf("merged.Version = %q, want %q", merged.Version, "1.0")
+	}
+	if merged.Timestamp.IsZero() {
+		t.Errorf("merged.Timestamp is zero; expected time.Now()")
+	}
+}

--- a/internal/coverage/model.go
+++ b/internal/coverage/model.go
@@ -97,6 +97,33 @@ func (c *Coverage) GetFiles() []string {
 	return files
 }
 
+// Merge combines multiple Coverage objects into a single Coverage by summing
+// per-position hit counts for each file. The result's Version mirrors
+// NewCoverage's "1.0" schema identifier and Timestamp is set to the current
+// time. Input coverages are not mutated; the returned Coverage owns its
+// position maps. Nil entries are skipped; an all-nil or empty input returns a
+// freshly initialized Coverage with no positions.
+func Merge(coverages ...*Coverage) *Coverage {
+	result := NewCoverage()
+	for _, c := range coverages {
+		if c == nil {
+			continue
+		}
+		for file, posHits := range c.Positions {
+			if posHits == nil {
+				continue
+			}
+			if result.Positions[file] == nil {
+				result.Positions[file] = make(PositionHits)
+			}
+			for posKey, hits := range posHits {
+				result.Positions[file][posKey] += hits
+			}
+		}
+	}
+	return result
+}
+
 // Clone returns a deep copy of the Coverage struct
 func (c *Coverage) Clone() *Coverage {
 	clone := &Coverage{


### PR DESCRIPTION
Implements finding **E1** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.