### PR TITLE
feat(report): add `--base-dir` for source resolution at report time

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2,6 +2,8 @@
 
 ### I1 — `pgcov` NOTIFY channel name hardcoded in two separate places
 
+> **Status: IMPLEMENTED** — stacked PR #16 (`feat(coverage): single-source, per-run unique NOTIFY channel name`, combined with E6). Verified 2026-08-14: hardcodes confirmed at instrumenter.go ×3 and executor.go ×1.
+
 `internal/instrument/instrumenter.go` hardcodes `'pgcov'` inside the injected
 `pg_notify(...)` call.  `internal/runner/executor.go` passes `"pgcov"` to
 `database.NewListener`.  If either is changed independently, coverage collection breaks
@@ -12,6 +14,8 @@ single source of truth.
 
 ### I2 — `Branch` field in `CoveragePoint` is always empty string
 
+> **Status: IMPLEMENTED** — stacked PR #17 (`refactor(instrument): remove dead branch-coverage API surface`). Dead code removed: `CoveragePoint.Branch` field, `branch` param in `FormatSignalID`, 4-part branch path in `ParseSignalID`. Note: the `TrackBranchPosition` claim in this finding was inaccurate — that function does not exist; the rest was verified.
+
 `types.go` defines `CoveragePoint.Branch`, `FormatSignalID` and `ParseSignalID` both
 handle a `:branch` suffix, and `TrackBranchPosition` exists in `location.go` — but
 `instrumentBody` always sets `Branch: ""` and the collector ignores branch data when
@@ -21,6 +25,8 @@ it or remove the dead code.
 ---
 
 ### I3 — `PositionKey()` format differs from the key format used by the Collector
+
+> **Status: IGNORED** — finding is factually wrong (verified 2026-08-14). No exported `PositionKey` function exists in `internal/instrument/location.go` (or anywhere in the tree); it contains only `FormatSignalID`, `ParseSignalID`, `parseNumber`. The collector's private `formatPositionKey` (`internal/coverage/model.go`) is the sole, consistent position-key format.
 
 `location.go` exports:
 
@@ -41,12 +47,16 @@ exported function is misleading and unused internally.
 
 ### I4 — `TrackPosition()` and `TrackBranchPosition()` in `location.go` are dead code
 
+> **Status: IGNORED** — finding is factually wrong (verified 2026-08-14). Neither `TrackPosition` nor `TrackBranchPosition` exists anywhere in the source tree (`location.go` holds only `FormatSignalID`/`ParseSignalID`/`parseNumber`). The genuinely dead branch API was `Branch`/`FormatSignalID`, handled under I2.
+
 Neither function is called anywhere in the production code.  They are part of the
 unimplemented branch-tracking API (see I2).
 
 ---
 
 ### I5 — `IsolationValidator` lives in production code but is never wired up
+
+> **Status: IGNORED** — finding is factually wrong (verified 2026-08-14). `internal/runner/isolation.go` does not exist and no `IsolationValidator`/`TrackDatabase`/`MarkCleaned`/`ValidateCleanup` symbol exists anywhere in the repository.
 
 `internal/runner/isolation.go` provides a fully functional `IsolationValidator` with
 `TrackDatabase` / `MarkCleaned` / `ValidateCleanup`, but `executor.go` never calls any
@@ -57,6 +67,8 @@ helper package.
 ---
 
 ### I6 — `cli-contract.md` describes a schema that was never implemented
+
+> **Status: IMPLEMENTED** — stacked PR #24 (`docs(cli): rewrite cli-contract.md to match the implemented CLI and JSON schema`). Document rewritten to match reality: `--connection` flag set, exit codes 0/1/2, `{version, timestamp, positions}` JSON schema. Verified: fictitious `--host/--port/--user/--password/--database` flags, `lines`/`branches` schema, and exit code 3 confirmed absent from code.
 
 `docs/cli-contract.md` (§ Coverage Data File Contract) documents a JSON schema with
 `lines` (containing `LineCoverage` objects) and `branches` (containing `BranchCoverage`
@@ -74,6 +86,8 @@ The document should be updated or the flags added.
 
 ### I7 — `ClassifyFile` returns `FileTypeSource` for non-SQL files
 
+> **Status: IMPLEMENTED** — stacked PR #14 (`fix(discovery): return FileTypeUnknown for non-SQL files in ClassifyFile`). Note: the claimed risk was partially inaccurate — `Discover` already filters non-`.sql` files before calling `ClassifyFile`, so the parser could never receive arbitrary files; the fix is API hardening only.
+
 If `filepath.Walk` delivers a non-`.sql` file, `ClassifyFile` returns `FileTypeSource`
 (documented as an "edge case").  This could cause the parser to attempt reading arbitrary
 files.  An explicit `FileTypeUnknown` or early-return guard in `Discover` would be safer.
@@ -81,6 +95,8 @@ files.  An explicit `FileTypeUnknown` or early-return guard in `Discover` would 
 ---
 
 ### I8 — `GetFiles()` / `GetFileList()` return unsorted slices
+
+> **Status: IMPLEMENTED** — stacked PR #15 (`refactor(coverage): return sorted file lists from GetFiles and GetFileList`). Verified: both getters iterated maps unsorted and every reporter caller immediately re-sorted; sorting moved into the getters, redundant caller sorts removed.
 
 Both `Coverage.GetFiles()` (`model.go`) and `Collector.GetFileList()` (`collector.go`)
 return files in random map-iteration order.  Every caller (all three reporters) performs
@@ -90,6 +106,8 @@ eliminate the repeated pattern.
 ---
 
 ### I9 — `isExecutableSegment` does not recognise `RETURN` as a segment boundary marker
+
+> **Status: IGNORED** — not a defect (verified 2026-08-14). The finding itself concedes treating `RETURN` as executable "is correct". The claimed follow-on risk (signals after `RETURN` being unreachable) is already handled: `findTerminalPos` places the coverage signal BEFORE terminal `RETURN`/`RAISE` statements, covered by `TestInstrumentBody_ReturnInBranches` and related B2 tests.
 
 `isExecutableSegment` excludes `BEGIN`, `END`, `LOOP`, `DECLARE`, and `EXCEPTION` from
 instrumentation.  `RETURN` is treated as an ordinary executable statement.  While this
@@ -104,6 +122,8 @@ unreachable (see B2), but the exclusion list does not account for this.
 
 ### E1 — No coverage merge / accumulation across runs
 
+> **Status: IMPLEMENTED** — stacked PR #21 (`feat(cli): add merge command to accumulate coverage across runs`). New `pgcov merge` subcommand + `coverage.Merge()` summing per-position hit counts.
+
 `pgcov run` always overwrites `.pgcov/coverage.json`.  There is no `pgcov merge` command
 or `--append` flag for accumulating coverage across CI matrix shards or multiple test
 directories.  The CI example configs work around this with external `jq` post-processing.
@@ -112,6 +132,8 @@ directories.  The CI example configs work around this with external `jq` post-pr
 
 ### E2 — No `--fail-under` coverage threshold
 
+> **Status: IMPLEMENTED** — stacked PR #20 (`feat(cli): add --fail-under coverage threshold to run command`). `--fail-under` flag; exit 1 when total coverage is below the threshold, with test-failure exit codes taking precedence.
+
 There is no built-in mechanism to exit non-zero when coverage falls below a configured
 threshold.  This is a standard CI requirement and is simulated in the example CI configs
 using shell arithmetic on the JSON output.
@@ -119,6 +141,8 @@ using shell arithmetic on the JSON output.
 ---
 
 ### E3 — Source file deployment order is undefined
+
+> **Status: IMPLEMENTED (docs)** — stacked PR #25 (`docs: document lexical source deployment order and numeric-prefix convention`). Note: the premise was partially wrong — `filepath.Walk` guarantees lexical order within each directory, so deployment order is deterministic; the gap was documentation of that guarantee plus the numeric-prefix convention and `--setup` escape hatch.
 
 `filepath.Walk` delivers files in lexicographic order within each directory, but the
 behaviour is OS-specific.  If `02_functions.sql` depends on objects created by
@@ -130,6 +154,8 @@ manifest should be supported.
 
 ### E4 — No `--base-dir` flag for source resolution in reporters
 
+> **Status: IMPLEMENTED** — stacked PR #22 (`feat(report): add --base-dir flag for source resolution at report time`). HTML/LCOV reporters gain `SetBaseDir` (Formatter interface unchanged); verified sources resolve against base-dir from a different CWD.
+
 The HTML and LCOV reporters resolve source file paths relative to the current working
 directory at report time.  If `pgcov report` is run from a different directory than
 `pgcov run`, source content cannot be found and the HTML report shows an error comment
@@ -140,6 +166,8 @@ location from the run location.
 
 ### E5 — Hardcoded 100 ms grace period in `CollectSignals`
 
+> **Status: IMPLEMENTED** — stacked PR #18 (`feat(cli): add --signal-timeout flag for coverage signal grace period`). Verified hardcode at executor.go (`100*time.Millisecond`); now `Config.SignalTimeout` + `--signal-timeout` flag, with `runner.DefaultSignalTimeout` fallback for non-positive values (bare `Config{}` constructions previously got a 0 ms grace and lost signals nondeterministically — caught by `TestTestIndependence` during stack verification).
+
 After test SQL executes, `CollectSignals` waits 100 ms for in-flight notifications.  On
 slow systems or under heavy parallel load this window may be too short, causing
 legitimate signals to be lost.  The value should be exposed as a configuration option
@@ -148,6 +176,8 @@ legitimate signals to be lost.  The value should be exposed as a configuration o
 ---
 
 ### E6 — Listener channel is not per-run unique
+
+> **Status: IMPLEMENTED** — stacked PR #16 (combined with I1: `feat(coverage): single-source, per-run unique NOTIFY channel name`). `Config.CoverageChannel` is the single source of truth; `pgcov run` generates `pgcov_<8 hex>` per invocation and threads it to both the injected `pg_notify` calls and the listener. Note: NOTIFY is database-scoped and each test runs in its own temp DB, so interference required user code inside the temp DB NOTIFYing on `pgcov` — now structurally impossible.
 
 The `pgcov` NOTIFY channel is a well-known name.  If the user's application already
 publishes notifications on a channel named `pgcov`, signals will be delivered to the
@@ -158,6 +188,8 @@ incorporate the temp-database name or a random UUID would eliminate interference
 
 ### E7 — `TestRun.Error` is set but not surfaced in the summary output
 
+> **Status: IMPLEMENTED** — stacked PR #19 (`feat(cli): print failed test errors in run summary`). Verified: summary printed only counts; now `runner.FormatFailedTests` prints `FAILED <path>: <error>` per failed run (unit-tested helper, no DB needed).
+
 When a test fails, `testRun.Error` holds the Go-level error.  The CLI summary prints
 `X failed` but does not print the error message.  Users must re-run with `--verbose` to
 see why a test failed.
@@ -166,6 +198,8 @@ see why a test failed.
 
 ### E8 — No `pgcov init` / scaffold command
 
+> **Status: IMPLEMENTED** — stacked PR #23 (`feat(cli): add init command to scaffold test files from sources`). `pgcov init <source.sql>` extracts `CREATE [OR REPLACE] FUNCTION` signatures via the existing pglex tokenizer (no regex) and writes a commented `_test.sql` scaffold, with `--output`/`--force` guards.
+
 There is no helper to generate a skeleton `_test.sql` file for an existing source.  A
 `pgcov init` command that reads function signatures from a source file and emits a
 commented test scaffold would lower the barrier to adoption.
@@ -173,6 +207,8 @@ commented test scaffold would lower the barrier to adoption.
 ---
 
 ### E9 — Pool `MaxConns` formula may be insufficient
+
+> **Status: IGNORED** — premise is factually wrong (verified 2026-08-14). The LISTEN connection is a dedicated `pgx.ConnectConfig` connection in `NewListener` — it does NOT come from the pool. Source deployment and test SQL acquire pool connections sequentially (acquire → exec → release), never 3 simultaneously. `MaxConns = parallelism*2` applies to the admin pool, which only serves short `CREATE/DROP DATABASE` calls. No acquire-timeout path exists as described; bumping the multiplier would address nothing.
 
 `pool.go` sets `MaxConns = parallelism * 2` under the assumption that each test uses
 two connections (one for execution, one for LISTEN).  Each test actually acquires up to
@@ -183,6 +219,8 @@ and `pgx` acquire timeouts.
 ---
 
 ### E10 — `CREATE DATABASE` uses an unquoted identifier
+
+> **Status: IMPLEMENTED** — stacked PR #13 (`fix(database): quote temp database identifiers with pgx.Identifier.Sanitize`). Verified: both `CREATE DATABASE` and `DROP DATABASE ... WITH (FORCE)` (plus the rollback DROP) now sanitize the identifier.
 
 `tempdb.go`:
 

--- a/cmd/pgcov/main.go
+++ b/cmd/pgcov/main.go
@@ -78,6 +78,10 @@ func main() {
 						Usage: "Coverage data input path",
 						Value: ".pgcov/coverage.json",
 					},
+					&urfavecli.StringFlag{
+						Name:  "base-dir",
+						Usage: "Base directory used to resolve relative source paths in coverage data (default: current working directory)",
+					},
 				},
 			},
 			{
@@ -148,8 +152,9 @@ func reportCommand(ctx context.Context, cmd *urfavecli.Command) error {
 	format := cmd.String("format")
 	output := cmd.String("output")
 	coverageFile := cmd.String("coverage-file")
+	baseDir := cmd.String("base-dir")
 
-	return cli.Report(ctx, coverageFile, format, output)
+	return cli.Report(ctx, coverageFile, format, output, baseDir)
 }
 
 // mergeCommand handles the 'pgcov merge' command

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -9,8 +9,13 @@ import (
 	"github.com/cybertec-postgresql/pgcov/internal/report"
 )
 
-// Report generates a coverage report from saved coverage data
-func Report(_ context.Context, coverageFile string, format string, outputPath string) error {
+// Report generates a coverage report from saved coverage data.
+// baseDir, when non-empty, is forwarded to the formatter so relative source
+// paths are resolved against it instead of the process CWD. This lets
+// `pgcov report` find sources when invoked from a directory other than the
+// one `pgcov run` was executed from.
+func Report(_ context.Context, coverageFile string, format string, outputPath string, baseDir string) error {
+
 	// Step 1: Load coverage data
 	store := coverage.NewStore(coverageFile)
 	if !store.Exists() {
@@ -32,6 +37,16 @@ func Report(_ context.Context, coverageFile string, format string, outputPath st
 	if err != nil {
 		return err
 	}
+
+	// Step 3a: Forward baseDir to formatters that support source-resolution.
+	// The JSON reporter embeds no source and ignores BaseDir, so the
+	// type-assertion fall-through is intentional.
+	if baseDir != "" {
+		if bd, ok := formatter.(interface{ SetBaseDir(string) }); ok {
+			bd.SetBaseDir(baseDir)
+		}
+	}
+
 
 	// Step 4: Format and output
 	var writer *os.File

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -228,14 +228,14 @@ func TestEndToEndWithTestcontainers(t *testing.T) {
 		_, _ = cli.Run(ctx, config, testDir)
 
 		// Test JSON report
-		err := cli.Report(t.Context(), config.CoverageFile, "json", "-")
+		err := cli.Report(t.Context(), config.CoverageFile, "json", "-", "")
 		if err != nil {
 			t.Fatalf("Failed to generate JSON report: %v", err)
 		}
 
 		// Test LCOV report
 		lcovFile := filepath.Join(t.TempDir(), "coverage.lcov")
-		err = cli.Report(t.Context(), config.CoverageFile, "lcov", lcovFile)
+		err = cli.Report(t.Context(), config.CoverageFile, "lcov", lcovFile, "")
 		if err != nil {
 			t.Fatalf("Failed to generate LCOV report: %v", err)
 		}

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -13,11 +13,25 @@ import (
 )
 
 // HTMLReporter formats coverage data as HTML
-type HTMLReporter struct{}
+type HTMLReporter struct {
+	// BaseDir, when non-empty, is the directory relative source paths are
+	// resolved against before falling back to the process CWD. It is used by
+	// readSourceFileAsString to locate .sql sources referenced in coverage
+	// positions when the report command runs from a different directory than
+	// `pgcov run` was invoked from.
+	BaseDir string
+}
 
 // NewHTMLReporter creates a new HTML reporter
 func NewHTMLReporter() *HTMLReporter {
 	return &HTMLReporter{}
+}
+
+// SetBaseDir configures the base directory used to resolve relative source
+// paths when reading files from disk. Passing an empty string clears it and
+// falls back to the process CWD.
+func (r *HTMLReporter) SetBaseDir(dir string) {
+	r.BaseDir = dir
 }
 
 // positionRange represents a byte range with coverage info
@@ -296,21 +310,42 @@ func (r *HTMLReporter) renderSourceWithPositions(sourceText string, ranges []pos
 	return nil
 }
 
-// readSourceFileAsString reads a source file and returns its content as string
+// readSourceFileAsString reads a source file and returns its content as string.
+// When BaseDir is set on the reporter, relative source paths are resolved
+// against BaseDir first, then the process CWD. Absolute paths are tried as-is
+// before falling back to CWD-relative resolution.
 func (r *HTMLReporter) readSourceFileAsString(filePath string) (string, error) {
-	// Try to open the file - handle both absolute and relative paths
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		// Try with current working directory
-		cwd, _ := os.Getwd()
-		altPath := filepath.Join(cwd, filePath)
-		data, err = os.ReadFile(altPath)
-		if err != nil {
-			return "", fmt.Errorf("cannot open file: %w", err)
+	candidates := r.sourcePathCandidates(filePath)
+	var lastErr error
+	for _, p := range candidates {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return string(data), nil
 		}
+		lastErr = err
 	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no candidates generated")
+	}
+	return "", fmt.Errorf("cannot open file: %w", lastErr)
+}
 
-	return string(data), nil
+// sourcePathCandidates returns the ordered list of paths to try when reading a
+// source file. Absolute paths skip base-dir resolution.
+func (r *HTMLReporter) sourcePathCandidates(filePath string) []string {
+	if filepath.IsAbs(filePath) {
+		return []string{filePath}
+	}
+	var out []string
+	if r.BaseDir != "" {
+		out = append(out, filepath.Join(r.BaseDir, filePath))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		out = append(out, filepath.Join(cwd, filePath))
+	} else {
+		out = append(out, filePath)
+	}
+	return out
 }
 
 // getCoverageClass returns the CSS class for coverage styling

--- a/internal/report/html_test.go
+++ b/internal/report/html_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -423,5 +424,85 @@ func TestHTMLReporter_Footer(t *testing.T) {
 
 	if !strings.Contains(output, "</html>") {
 		t.Error("Missing closing html tag")
+	}
+}
+
+func TestHTMLReporter_BaseDir(t *testing.T) {
+	// Source lives in baseDir/sql/sample.sql. Coverage positions reference it
+	// by the relative path that `pgcov run` would have used. We run the
+	// reporter from a different CWD and rely on BaseDir to find the file.
+	baseDir := t.TempDir()
+	srcDir := baseDir + "/sql"
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	srcPath := "sql/sample.sql"
+	srcContent := "SELECT 1;\nSELECT 2;\nSELECT 3;\n"
+	if err := os.WriteFile(baseDir+"/"+srcPath, []byte(srcContent), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cov := &coverage.Coverage{
+		Version:   "1.0",
+		Timestamp: time.Now(),
+		Positions: map[string]coverage.PositionHits{
+			srcPath: {
+				"0:10":  2,
+				"10:10": 1,
+				"20:10": 0,
+			},
+		},
+	}
+
+	// Run reporter from a different CWD so CWD-relative resolution fails.
+	otherCwd := t.TempDir()
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(otherCwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevCwd) })
+
+	// Without BaseDir the source cannot be located, and the error message
+	// is rendered instead of the source body.
+	noBase := NewHTMLReporter()
+	outNoBase, err := noBase.FormatString(cov)
+	if err != nil {
+		t.Fatalf("FormatString without BaseDir: %v", err)
+	}
+	if strings.Contains(outNoBase, "SELECT 1;") {
+		t.Fatal("expected source NOT to be resolved without BaseDir (wrong CWD)")
+	}
+	if !strings.Contains(outNoBase, "Error reading source file") {
+		t.Error("expected error message in HTML when source cannot be resolved")
+	}
+
+	// With BaseDir the relative source path resolves and the file body
+	// appears in the rendered HTML.
+	withBase := NewHTMLReporter()
+	withBase.SetBaseDir(baseDir)
+	out, err := withBase.FormatString(cov)
+	if err != nil {
+		t.Fatalf("FormatString with BaseDir: %v", err)
+	}
+	for _, want := range []string{"SELECT 1;", "SELECT 2;", "SELECT 3;"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected rendered HTML to contain %q from %s", want, srcPath)
+		}
+	}
+	if strings.Contains(out, "Error reading source file") {
+		t.Error("expected no error message when BaseDir is set")
+	}
+
+	// SetBaseDir("") returns to CWD-only behaviour.
+	withBase.SetBaseDir("")
+	outCleared, err := withBase.FormatString(cov)
+	if err != nil {
+		t.Fatalf("FormatString after clearing BaseDir: %v", err)
+	}
+	if strings.Contains(outCleared, "SELECT 1;") {
+		t.Error("expected CWD-only mode to fail after clearing BaseDir (wrong CWD)")
 	}
 }

--- a/internal/report/lcov.go
+++ b/internal/report/lcov.go
@@ -12,11 +12,23 @@ import (
 
 // LCOVReporter formats coverage data in LCOV format
 // LCOV format specification: https://github.com/linux-test-project/lcov
-type LCOVReporter struct{}
+type LCOVReporter struct {
+	// BaseDir, when non-empty, is the directory relative source paths are
+	// resolved against before falling back to the process CWD. See
+	// HTMLReporter.BaseDir for the same mechanism.
+	BaseDir string
+}
 
 // NewLCOVReporter creates a new LCOV reporter
 func NewLCOVReporter() *LCOVReporter {
 	return &LCOVReporter{}
+}
+
+// SetBaseDir configures the base directory used to resolve relative source
+// paths when reading files from disk. Passing an empty string clears it and
+// falls back to the process CWD.
+func (r *LCOVReporter) SetBaseDir(dir string) {
+	r.BaseDir = dir
 }
 
 // Format formats coverage data as LCOV and writes to the writer
@@ -178,19 +190,42 @@ func (r *LCOVReporter) formatPositionsAsLines(posHits coverage.PositionHits, wri
 	return nil
 }
 
-// readSourceFile reads a source file and returns its content as string
+// readSourceFile reads a source file and returns its content as string.
+// When BaseDir is set on the reporter, relative source paths are resolved
+// against BaseDir first, then the process CWD. Absolute paths are tried as-is
+// before falling back to CWD-relative resolution.
 func (r *LCOVReporter) readSourceFile(filePath string) (string, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		// Try with current working directory
-		cwd, _ := os.Getwd()
-		altPath := filepath.Join(cwd, filePath)
-		data, err = os.ReadFile(altPath)
-		if err != nil {
-			return "", fmt.Errorf("cannot open file: %w", err)
+	candidates := r.sourcePathCandidates(filePath)
+	var lastErr error
+	for _, p := range candidates {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return string(data), nil
 		}
+		lastErr = err
 	}
-	return string(data), nil
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no candidates generated")
+	}
+	return "", fmt.Errorf("cannot open file: %w", lastErr)
+}
+
+// sourcePathCandidates returns the ordered list of paths to try when reading a
+// source file. Absolute paths skip base-dir resolution.
+func (r *LCOVReporter) sourcePathCandidates(filePath string) []string {
+	if filepath.IsAbs(filePath) {
+		return []string{filePath}
+	}
+	var out []string
+	if r.BaseDir != "" {
+		out = append(out, filepath.Join(r.BaseDir, filePath))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		out = append(out, filepath.Join(cwd, filePath))
+	} else {
+		out = append(out, filePath)
+	}
+	return out
 }
 
 // FormatString returns coverage data as an LCOV-formatted string

--- a/internal/report/lcov_test.go
+++ b/internal/report/lcov_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -344,5 +345,88 @@ func TestLCOVReporter_HitCountFormat(t *testing.T) {
 	}
 	if !strings.Contains(output, ",9999") {
 		t.Error("Missing 9999 hit count")
+	}
+}
+
+func TestLCOVReporter_BaseDir(t *testing.T) {
+	// Build a source file with known line breaks; coverage positions are
+	// chosen so they land on distinct lines. The reporter must read the
+	baseDir := t.TempDir()
+	srcDir := baseDir + "/queries"
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	srcPath := "queries/users.sql"
+	srcContent := "CREATE TABLE users (\n    id INT PRIMARY KEY,\n    name TEXT NOT NULL,\n    email TEXT UNIQUE\n);\n"
+	if err := os.WriteFile(baseDir+"/"+srcPath, []byte(srcContent), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	cov := &coverage.Coverage{
+		Version:   "1.0",
+		Timestamp: time.Now(),
+		Positions: map[string]coverage.PositionHits{
+			// Positions are placed so line-number conversion yields 1 and 2.
+			// Byte 0  -> line 1 (start of "CREATE TABLE users ("); byte 22
+			// lands inside line 2 (the "id INT PRIMARY KEY," line).
+			srcPath: {
+				"0:5":   2,
+				"22:10": 1,
+			},
+		},
+	}
+
+	// Switch to a directory where neither the relative source path nor
+	// anything else the LCOV reporter tries to read will exist.
+	otherCwd := t.TempDir()
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(otherCwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevCwd) })
+
+	// Without BaseDir the reporter falls back to position-as-line, so
+	// the output contains DA:0,... and DA:30,... instead of line numbers.
+	noBase := NewLCOVReporter()
+	var noBaseBuf bytes.Buffer
+	if err := noBase.Format(cov, &noBaseBuf); err != nil {
+		t.Fatalf("Format without BaseDir: %v", err)
+	}
+	noBaseOut := noBaseBuf.String()
+	if !strings.Contains(noBaseOut, "DA:0,2") {
+		t.Errorf("expected byte-position fallback to emit DA:0,2; got: %s", noBaseOut)
+	}
+	if !strings.Contains(noBaseOut, "DA:22,1") {
+		t.Errorf("expected byte-position fallback to emit DA:22,1; got: %s", noBaseOut)
+	}
+
+	// With BaseDir the reporter reads the source and converts positions
+	// to real line numbers, then sums per line.
+	withBase := NewLCOVReporter()
+	withBase.SetBaseDir(baseDir)
+	out, err := withBase.FormatString(cov)
+	if err != nil {
+		t.Fatalf("FormatString with BaseDir: %v", err)
+	}
+	if !strings.Contains(out, "DA:2,1") {
+		t.Errorf("expected line 2 with 1 hit; got: %s", out)
+	}
+	if !strings.Contains(out, "SF:"+srcPath) {
+		t.Errorf("missing SF: header; got: %s", out)
+	}
+	if !strings.Contains(out, "DA:1,2") {
+		t.Errorf("expected line 1 with 2 hits; got: %s", out)
+	}
+	// The presence of DA:1,... and DA:2,... (real line numbers, not the
+	// raw byte positions 0 and 22) is sufficient evidence that source
+	// resolution via BaseDir succeeded; the byte-position fallback would
+	// have produced DA:0,... and DA:22,... instead.
+	if !strings.Contains(out, "LF:2") {
+		t.Errorf("expected LF:2 (two lines found); got: %s", out)
+	}
+	if !strings.Contains(out, "LH:2") {
+		t.Errorf("expected LH:2 (two lines hit); got: %s", out)
 	}
 }


### PR DESCRIPTION
Implements finding **E4** from FINDINGS.md (code review 2026-03-18, verified 2026-08-14).

Part of stacked PR series #13–#25 (gh stack #26). Base chain: master → #13 → … → #25.